### PR TITLE
[#1] feat: 대분류 페이지 라우팅 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,24 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import Community from './pages/Community';
+import Diet from './pages/Diet';
 import Home from './pages/Home';
+import Join from './pages/Join';
+import Login from './pages/Login';
+import Mypage from './pages/Mypage';
+import Ranking from './pages/Ranking';
 
 const App = () => {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/diet" element={<Diet />} />
         <Route path="/community" element={<Community />} />
+        <Route path="/ranking" element={<Ranking />} />
+        <Route path="/mypage" element={<Mypage />} />
+        <Route path="/join" element={<Join />} />
+        <Route path="/login" element={<Login />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,11 +1,14 @@
 const Header = () => {
   return (
     <header className="w-full p-7 flex justify-between items-center">
-      <a href="/" className="text-2xl font-bold">Babit</a>
-      <nav className="space-x-6">
+      <a href="/" className="text-2xl font-bold">
+        Babit
+      </a>
+      <nav className="space-x-6 flex">
         <a href="/diet">식단관리</a>
+        <a href="/ranking">랭킹</a>
         <a href="/community">커뮤니티</a>
-        <a href="/profile">마이페이지</a>
+        <a href="/mypage">마이페이지</a>
       </nav>
     </header>
   );

--- a/src/pages/Diet.tsx
+++ b/src/pages/Diet.tsx
@@ -1,0 +1,12 @@
+import MainLayout from '../components/layout/Main';
+
+const Diet = () => {
+  return (
+    <MainLayout>
+      <h2 className="text-xl font-bold mb-4">식단 관리</h2>
+      {/* 내용 */}
+    </MainLayout>
+  );
+};
+
+export default Diet;

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -1,0 +1,12 @@
+import MainLayout from '../components/layout/Main';
+
+const Join = () => {
+  return (
+    <MainLayout>
+      <h2 className="text-xl font-bold mb-4">회원 가입</h2>
+      {/* 내용 */}
+    </MainLayout>
+  );
+};
+
+export default Join;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,12 @@
+import MainLayout from '../components/layout/Main';
+
+const Login = () => {
+  return (
+    <MainLayout>
+      <h2 className="text-xl font-bold mb-4">로그인</h2>
+      {/* 내용 */}
+    </MainLayout>
+  );
+};
+
+export default Login;

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,0 +1,12 @@
+import MainLayout from '../components/layout/Main';
+
+const Mypage = () => {
+  return (
+    <MainLayout>
+      <h2 className="text-xl font-bold mb-4">마이 페이지</h2>
+      {/* 내용 */}
+    </MainLayout>
+  );
+};
+
+export default Mypage;

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,0 +1,12 @@
+import MainLayout from '../components/layout/Main';
+
+const Ranking = () => {
+  return (
+    <MainLayout>
+      <h2 className="text-xl font-bold mb-4">랭킹</h2>
+      {/* 내용 */}
+    </MainLayout>
+  );
+};
+
+export default Ranking;


### PR DESCRIPTION
<!-- PR 제목 양식: [#{이슈번호}] {변경 유형}: {변경 내용} 
    예시: [#2] chore: PR 템플릿 추가 -->

## ✅ 작업 내용
- [x] `/pages` 디렉토리에 진입점이 되는 페이지 파일 추가
- [x] `App.tsx`에 라우팅 설정
- [x] `Header.tsx`에 `/ranking`, `/mypage`로 향하는 링크 추가

---

## 🔍 상세 내용
<!-- 구현 방식, 고려한 점, 논의할 사항 등 자세히 작성 -->

- `react-router-dom`을 활용하여 `App.tsx`에서 라우팅 관리
```jsx
// App.tsx
<BrowserRouter>
    <Routes>
        <Route path="/" element={<Home />} />
        ...
    </Routes>
</BrowserRouter>
```

- 헤더에 연결된 주요 라우터

  + `/diet` : 식단관리
  + `/ranking` : 마일리지 랭킹 확인
  + `/mypage` : 마이페이지
  + `/community` : 게시글

- 직접 URL 입력 시 접근 가능한 라우터

  + `/login` : 로그인
  + `/join` : 회원가입



---

## 📎 기타 참고 사항
<!-- 리뷰어가 참고하면 좋을 내용이나 링크 등 -->

- 모든 페이지 / 라우터 관련 내용은 담당 개발자가 변경해서 사용해도 됩니다.

- 추후 구현 가능한 라우터

  + `/diet/analysis` : 식단 관리 페이지 완성 이후 생성 예정
  + `/foods` : 구현 여부가 확정되지 않았으므로 미구현


---

## ➕ 관련 이슈
<!-- 예시: Closes #12 -->

Closes #1 